### PR TITLE
Add environment-based auth and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+terraform
+README.md

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+API_SECRET=your_api_secret

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Once deployed, find the public endpoint (ECS service public IP or load balancer 
 ```sh
 curl -X POST http://<service-endpoint>:3000/submit-feedback \
   -H "Content-Type: application/json" \
+  -H "x-api-key: <your_api_secret>" \
   -d '{ "message": "Loved the experience!" }'
 ```
 
@@ -92,6 +93,7 @@ curl -X POST http://<service-endpoint>:3000/submit-feedback \
 - Set method to POST
 - URL: `http://<service-endpoint>:3000/submit-feedback`
 - Body: raw JSON `{ "message": "Loved the experience!" }`
+- Header `x-api-key: <your_api_secret>`
 
 ## Project Structure
 ```

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const express = require('express');
+require('dotenv').config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 const API_SECRET = process.env.API_SECRET || 'default_secret';
@@ -7,6 +8,11 @@ app.use(express.json());
 
 // POST /submit-feedback endpoint
 app.post('/submit-feedback', (req, res) => {
+  const apiKey = req.headers['x-api-key'];
+  if (apiKey !== API_SECRET) {
+    return res.status(403).json({ error: 'Unauthorized' });
+  }
+
   const { message } = req.body;
   if (!message) {
     return res.status(400).json({ error: 'Message is required.' });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "dotenv": "^16.3.1"
   }
-} 
+}


### PR DESCRIPTION
## Summary
- add env example and docker ignore
- enhance API with header auth
- document API key usage
- add dotenv dependency

## Testing
- `npm install`
- `terraform init -backend=false` *(fails: Error accessing remote module registry)*

------
https://chatgpt.com/codex/tasks/task_e_683f86d4a52083238dd34a476eaaabe5