### PR TITLE
Add simple feedback web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@ const PORT = process.env.PORT || 3000;
 const API_SECRET = process.env.API_SECRET || 'default_secret';
 
 app.use(express.json());
+// Serve static files from the "public" directory
+app.use(express.static('public'));
 
 // POST /submit-feedback endpoint
 app.post('/submit-feedback', (req, res) => {

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Submit Feedback</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: auto; padding: 2rem; }
+    label, textarea, button { display: block; width: 100%; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Submit Feedback</h1>
+  <form id="feedback-form">
+    <label for="message">Your Feedback:</label>
+    <textarea id="message" rows="4" required></textarea>
+    <button type="submit">Send</button>
+  </form>
+  <div id="status"></div>
+  <script>
+    const form = document.getElementById('feedback-form');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = document.getElementById('message').value;
+      try {
+        const res = await fetch('/submit-feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message })
+        });
+        const data = await res.json();
+        document.getElementById('status').textContent = data.message || 'Success';
+        form.reset();
+      } catch (err) {
+        document.getElementById('status').textContent = 'Error sending feedback';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose `public/` static folder in Express
- add a minimal HTML form to post feedback
- keep node_modules and lockfile out of Git with .gitignore

## Testing
- `npm install`
- `node app.js &`
- `curl -s http://localhost:3000/ | head`
- `curl -s -X POST http://localhost:3000/submit-feedback -H 'Content-Type: application/json' -d '{"message":"hello"}'`

------
https://chatgpt.com/codex/tasks/task_e_683f87415cc08323ae12c9f645d03cac